### PR TITLE
Nullable support

### DIFF
--- a/src/Items.php
+++ b/src/Items.php
@@ -25,7 +25,7 @@ class Items extends Field
         parent::resolve($resource, $attribute);
 
         $this->fillUsing(function($request, $model, $attribute, $requestAttribute) {
-            $model->$attribute = json_decode($request->$attribute, true);
+            $model->$attribute = $this->isNullValue($request->$attribute) ? null : json_decode($request->$attribute, true);
         });
 
         $this->withMeta([


### PR DESCRIPTION
Support for the `->nullable()`, see: https://nova.laravel.com/docs/2.0/resources/fields.html#nullable-fields. So `null` can be stored instead of an empty array `[]`. 

To get this working we need to use one of these: 
- `->nullable(true, '[]')`
- `->nullable()->nullValues('[]')`

For reference: https://github.com/laravel/nova/blob/91301a38949885f0c29a9b962d193ca77cf5ee50/src/Fields/Field.php#L363